### PR TITLE
[Feature] performance.now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # stateful-dynamic-interval
-> :clock1: Stateful dynamic interval
+> :clock1: The stateful dynamic interval
 ---
 
 A pauseable and resumeable `setInterval` built around [dynamic-interval](https://github.com/slurmulon/dynamic-interval)

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -5,6 +5,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
 var setDynterval = _interopDefault(require('dynamic-interval'));
+var now = _interopDefault(require('performance-now'));
 
 var babelHelpers = {};
 
@@ -229,7 +230,7 @@ var StatefulDynterval = function () {
 
       // TODO: can probably eliminate the need for this by supporting III (immediately invoked interval) in `dynamic-interval`
       // TODO: experiment with only doing this if `config` is `null`
-      this.time.start = new Date();
+      this.time.start = now(); //new Date()
       this.time.clock.context = context || config;
 
       return context;
@@ -237,9 +238,11 @@ var StatefulDynterval = function () {
   }, {
     key: 'run',
     value: function run() {
-      this.time.start = new Date();
+      this.time.start = now(); //new Date()
       this.time.clock = setDynterval(this.next.bind(this), this.context, this.api); // TODO: play with just `this.context`
       this.state = STATES.running;
+
+      return this;
     }
   }, {
     key: 'pickup',
@@ -261,7 +264,9 @@ var StatefulDynterval = function () {
       if (this.state !== STATES.running) return;
 
       var wait = this.context.wait;
-      var elapsed = new Date() - this.time.start;
+      var start = this.time.start;
+
+      var elapsed = now() - start; //new Date() - this.time.start
 
       this.time.remaining = wait - elapsed;
       this.time.clock.clear();

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -239,7 +239,7 @@ var StatefulDynterval = function () {
     key: 'run',
     value: function run() {
       this.time.start = now(); //new Date()
-      this.time.clock = setDynterval(this.next.bind(this), this.context, this.api); // TODO: play with just `this.context`
+      this.time.clock = setDynterval(this.next.bind(this), this.context, this.api);
       this.state = STATES.running;
 
       return this;
@@ -266,7 +266,7 @@ var StatefulDynterval = function () {
       var wait = this.context.wait;
       var start = this.time.start;
 
-      var elapsed = now() - start; //new Date() - this.time.start
+      var elapsed = now() - start;
 
       this.time.remaining = wait - elapsed;
       this.time.clock.clear();

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -230,7 +230,7 @@ var StatefulDynterval = function () {
 
       // TODO: can probably eliminate the need for this by supporting III (immediately invoked interval) in `dynamic-interval`
       // TODO: experiment with only doing this if `config` is `null`
-      this.time.start = now(); //new Date()
+      this.time.start = now();
       this.time.clock.context = context || config;
 
       return context;
@@ -238,7 +238,7 @@ var StatefulDynterval = function () {
   }, {
     key: 'run',
     value: function run() {
-      this.time.start = now(); //new Date()
+      this.time.start = now();
       this.time.clock = setDynterval(this.next.bind(this), this.context, this.api);
       this.state = STATES.running;
 
@@ -309,6 +309,13 @@ var StatefulDynterval = function () {
       }
 
       this.children.push(interval);
+
+      return this;
+    }
+  }, {
+    key: 'detach',
+    value: function detach() {
+      this.children = [];
 
       return this;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -834,6 +834,9 @@
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
+    "dynamic-interval": {
+      "version": "github:slurmulon/dynamic-interval#29fb0810706f8f485fd0fd380ed99caa8d1dc8cb"
+    },
     "escape-string-regexp": {
       "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,29 @@
         "samsam": "1.3.0"
       }
     },
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "longest": "1.0.1",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
@@ -31,6 +54,15 @@
       "requires": {
         "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
         "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -54,6 +86,12 @@
     "assertion-error": {
       "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-each": {
@@ -637,9 +675,28 @@
       }
     },
     "browser-stdout": {
-      "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chai": {
       "version": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
@@ -688,6 +745,27 @@
         "readdirp": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
       }
     },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "commander": {
       "version": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
       "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
@@ -722,6 +800,13 @@
         "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
     "deep-eql": {
       "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.0.tgz",
       "integrity": "sha1-uRYqSc9LVNkRQll1rJXQPlZEhHE=",
@@ -729,6 +814,12 @@
       "requires": {
         "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
       }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "detect-indent": {
       "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -743,1469 +834,46 @@
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
-    "dynamic-interval": {
-      "version": "file:../dynamic-interval",
-      "dependencies": {
-        "@angular/core": {
-          "version": "5.2.1",
-          "bundled": true,
-          "requires": {
-            "tslib": "1.8.1"
-          }
-        },
-        "accurate-interval": {
-          "version": "1.0.9",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "anymatch": {
-          "version": "1.3.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "micromatch": "2.3.11",
-            "normalize-path": "2.1.1"
-          }
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "bundled": true,
-          "optional": true
-        },
-        "async-array-buffer": {
-          "version": "1.1.21",
-          "bundled": true,
-          "requires": {
-            "async-array-buffer-broker": "2.0.9",
-            "async-array-buffer-worker": "3.0.7",
-            "babel-runtime": "6.26.0",
-            "tslib": "1.9.0"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-              "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
-            }
-          }
-        },
-        "async-array-buffer-broker": {
-          "version": "2.0.9",
-          "bundled": true,
-          "requires": {
-            "async-array-buffer-worker": "3.0.7",
-            "babel-runtime": "6.26.0",
-            "broker-factory": "1.2.6",
-            "fast-unique-numbers": "1.1.3",
-            "tslib": "1.9.0"
-          },
-          "dependencies": {
-            "fast-unique-numbers": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-1.1.3.tgz",
-              "integrity": "sha512-PrrzbSBcYGzZG74cePBsy6DXqRlRu7x1R/+/MBNaSG99F5qvPUYxzLfv+iRMk2w3ap3UbqOM8021KoxWPgUXjQ==",
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "tslib": "1.9.0"
-              }
-            },
-            "tslib": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-              "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
-            }
-          }
-        },
-        "async-array-buffer-worker": {
-          "version": "3.0.7",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "tslib": "1.9.0",
-            "worker-factory": "2.1.3"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-              "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
-            }
-          }
-        },
-        "async-each": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "audio-context-timers": {
-          "version": "2.1.20",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "fast-unique-numbers": "1.1.3",
-            "standardized-audio-context": "11.0.13",
-            "tslib": "1.9.0"
-          },
-          "dependencies": {
-            "fast-unique-numbers": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-1.1.3.tgz",
-              "integrity": "sha512-PrrzbSBcYGzZG74cePBsy6DXqRlRu7x1R/+/MBNaSG99F5qvPUYxzLfv+iRMk2w3ap3UbqOM8021KoxWPgUXjQ==",
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "tslib": "1.9.0"
-              }
-            },
-            "tslib": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-              "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
-            }
-          }
-        },
-        "babel-cli": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-core": "6.26.0",
-            "babel-polyfill": "6.26.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "chokidar": "1.7.0",
-            "commander": "2.11.0",
-            "convert-source-map": "1.5.0",
-            "fs-readdir-recursive": "1.0.0",
-            "glob": "7.1.2",
-            "lodash": "4.17.4",
-            "output-file-sync": "1.1.2",
-            "path-is-absolute": "1.0.1",
-            "slash": "1.0.0",
-            "source-map": "0.5.7",
-            "v8flags": "2.1.1"
-          }
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-core": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.0",
-            "debug": "2.6.9",
-            "json5": "0.5.1",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
-          }
-        },
-        "babel-generator": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
-          }
-        },
-        "babel-helper-call-delegate": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-helper-define-map": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-helper-hoist-variables": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-helper-optimise-call-expression": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-helper-regex": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-helper-replace-supers": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-helpers": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
-          }
-        },
-        "babel-messages": {
-          "version": "6.23.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-check-es2015-constants": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-plugin-transform-es2015-classes": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-define-map": "6.26.0",
-            "babel-helper-function-name": "6.24.1",
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-          "version": "6.23.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-duplicate-keys": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-for-of": {
-          "version": "6.23.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-function-name": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-literals": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-modules-amd": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-transform-strict-mode": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-modules-systemjs": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-modules-umd": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-object-super": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-call-delegate": "6.24.1",
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-spread": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-          "version": "6.23.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "regexpu-core": "2.0.0"
-          }
-        },
-        "babel-plugin-transform-regenerator": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "regenerator-transform": "0.10.1"
-          }
-        },
-        "babel-plugin-transform-strict-mode": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-polyfill": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.10.5"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "bundled": true
-            }
-          }
-        },
-        "babel-preset-es2015": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-check-es2015-constants": "6.22.0",
-            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-            "babel-plugin-transform-es2015-classes": "6.24.1",
-            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-            "babel-plugin-transform-es2015-destructuring": "6.23.0",
-            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-            "babel-plugin-transform-es2015-for-of": "6.23.0",
-            "babel-plugin-transform-es2015-function-name": "6.24.1",
-            "babel-plugin-transform-es2015-literals": "6.22.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-            "babel-plugin-transform-es2015-object-super": "6.24.1",
-            "babel-plugin-transform-es2015-parameters": "6.24.1",
-            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-            "babel-plugin-transform-es2015-spread": "6.22.0",
-            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-            "babel-plugin-transform-es2015-template-literals": "6.22.0",
-            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-            "babel-plugin-transform-regenerator": "6.26.0"
-          }
-        },
-        "babel-register": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-core": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.1",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.4",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.17"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.11.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "binary-extensions": {
-          "version": "1.10.0",
-          "bundled": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "braces": {
-          "version": "1.8.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
-        },
-        "broker-factory": {
-          "version": "1.2.6",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "fast-unique-numbers": "1.1.3",
-            "tslib": "1.9.0",
-            "worker-factory": "2.1.3"
-          },
-          "dependencies": {
-            "fast-unique-numbers": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-1.1.3.tgz",
-              "integrity": "sha512-PrrzbSBcYGzZG74cePBsy6DXqRlRu7x1R/+/MBNaSG99F5qvPUYxzLfv+iRMk2w3ap3UbqOM8021KoxWPgUXjQ==",
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "tslib": "1.9.0"
-              }
-            },
-            "tslib": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-              "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
-            }
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "chokidar": {
-          "version": "1.7.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "anymatch": "1.3.2",
-            "async-each": "1.0.1",
-            "glob-parent": "2.0.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "2.0.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
-          }
-        },
-        "commander": {
-          "version": "2.11.0",
-          "bundled": true
-        },
-        "compilerr": {
-          "version": "4.1.3",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "dashify": "1.0.0",
-            "indefinite-article": "0.0.2",
-            "tslib": "1.9.0"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-              "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
-            }
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "convert-source-map": {
-          "version": "1.5.0",
-          "bundled": true
-        },
-        "core-js": {
-          "version": "2.5.1",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "dashify": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "detect-indent": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fill-range": "2.2.3"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "fast-unique-numbers": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "tslib": "1.8.1"
-          }
-        },
-        "filename-regex": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "for-in": "1.0.2"
-          }
-        },
-        "fs-readdir-recursive": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "is-glob": "2.0.1"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "bundled": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "home-or-tmp": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "indefinite-article": {
-          "version": "0.0.2",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "binary-extensions": "1.10.0"
-          }
-        },
-        "is-buffer": {
-          "version": "1.1.5",
-          "bundled": true
-        },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "is-primitive": "2.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "bundled": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "nanotimer": {
-          "version": "0.3.15",
-          "bundled": true
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "remove-trailing-separator": "1.1.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "output-file-sync": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "present": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "preserve": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "private": {
-          "version": "0.1.7",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "optional": true
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "is-buffer": "1.1.5"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "readdirp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "readable-stream": "2.3.3",
-            "set-immediate-shim": "1.0.1"
-          }
-        },
-        "regenerate": {
-          "version": "1.3.2",
-          "bundled": true
-        },
-        "regenerator-runtime": {
-          "version": "0.11.0",
-          "bundled": true
-        },
-        "regenerator-transform": {
-          "version": "0.10.1",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "private": "0.1.7"
-          }
-        },
-        "regex-cache": {
-          "version": "0.4.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "is-equal-shallow": "0.1.3"
-          }
-        },
-        "regexpu-core": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "regenerate": "1.3.2",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
-          }
-        },
-        "regjsgen": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "regjsparser": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "jsesc": "0.5.0"
-          },
-          "dependencies": {
-            "jsesc": {
-              "version": "0.5.0",
-              "bundled": true
-            }
-          }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true,
-          "optional": true
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "request-interval": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "rolex": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "present": "0.0.3"
-          },
-          "dependencies": {
-            "present": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/present/-/present-0.0.3.tgz",
-              "integrity": "sha1-Wu+4pd32s0xldDvxzeU1I6rBwFo="
-            }
-          }
-        },
-        "rxjs": {
-          "version": "5.5.6",
-          "bundled": true,
-          "requires": {
-            "symbol-observable": "1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "set-immediate-shim": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "slash": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true
-        },
-        "source-map-support": {
-          "version": "0.4.17",
-          "bundled": true,
-          "requires": {
-            "source-map": "0.5.7"
-          }
-        },
-        "standardized-audio-context": {
-          "version": "11.0.13",
-          "bundled": true,
-          "requires": {
-            "@angular/core": "5.2.1",
-            "async-array-buffer": "1.1.21",
-            "babel-runtime": "6.26.0",
-            "rxjs": "5.5.6",
-            "tslib": "1.9.0",
-            "zone.js": "0.8.20"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-              "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "symbol-observable": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "trim-right": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "tslib": {
-          "version": "1.8.1",
-          "bundled": true
-        },
-        "user-home": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "v8flags": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "user-home": "1.1.1"
-          }
-        },
-        "worker-factory": {
-          "version": "2.1.3",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "compilerr": "4.1.3",
-            "fast-unique-numbers": "1.1.3",
-            "tslib": "1.9.0"
-          },
-          "dependencies": {
-            "fast-unique-numbers": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-1.1.3.tgz",
-              "integrity": "sha512-PrrzbSBcYGzZG74cePBsy6DXqRlRu7x1R/+/MBNaSG99F5qvPUYxzLfv+iRMk2w3ap3UbqOM8021KoxWPgUXjQ==",
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "tslib": "1.9.0"
-              }
-            },
-            "tslib": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-              "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
-            }
-          }
-        },
-        "worker-timers": {
-          "version": "4.0.20",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "tslib": "1.8.1",
-            "worker-timers-broker": "4.0.10",
-            "worker-timers-worker": "4.0.8"
-          }
-        },
-        "worker-timers-broker": {
-          "version": "4.0.10",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "fast-unique-numbers": "1.1.2",
-            "tslib": "1.8.1",
-            "worker-timers-worker": "4.0.8"
-          }
-        },
-        "worker-timers-worker": {
-          "version": "4.0.8",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "tslib": "1.8.1"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "zone.js": {
-          "version": "0.8.20",
-          "bundled": true
-        }
-      }
-    },
     "escape-string-regexp": {
       "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
       "dev": true
     },
     "estree-walker": {
@@ -2241,6 +909,12 @@
       "requires": {
         "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
       }
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "filename-regex": {
       "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -3232,14 +1906,39 @@
       "dev": true
     },
     "graceful-readlink": {
-      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "growl": {
-      "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
     },
     "has-ansi": {
       "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -3252,6 +1951,12 @@
     "has-flag": {
       "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
     "home-or-tmp": {
@@ -3361,6 +2066,12 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "isobject": {
       "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
@@ -3369,10 +2080,74 @@
         "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
       }
     },
+    "istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.11",
+        "js-yaml": "3.11.0",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nopt": "3.0.6",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.3.0",
+        "wordwrap": "1.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
+        }
+      }
+    },
     "js-tokens": {
       "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        }
+      }
     },
     "jsesc": {
       "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -3380,7 +2155,8 @@
       "dev": true
     },
     "json3": {
-      "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
@@ -3403,48 +2179,71 @@
         "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
       }
     },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
     "lodash": {
       "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
     "lodash._baseassign": {
-      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash._basecopy": {
-      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
-      "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
-      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
-      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.create": {
-      "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-        "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
       }
     },
     "lodash.get": {
@@ -3454,29 +2253,38 @@
       "dev": true
     },
     "lodash.isarguments": {
-      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
-      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.keys": {
-      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lolex": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
       "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loose-envify": {
@@ -3529,33 +2337,37 @@
       }
     },
     "mocha": {
-      "version": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
-      "integrity": "sha1-EyhWfScX+ZcDD4AGI0vOm4zXJGU=",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
       "requires": {
-        "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
         "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
         "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
         "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-        "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
         "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+        "supports-color": "3.1.2"
       },
       "dependencies": {
         "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            "graceful-readlink": "1.0.1"
           }
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
@@ -3568,7 +2380,8 @@
           }
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
@@ -3600,6 +2413,15 @@
         "lolex": "2.3.2",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
       }
     },
     "normalize-path": {
@@ -3635,6 +2457,38 @@
       "dev": true,
       "requires": {
         "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "os-homedir": {
@@ -3693,6 +2547,17 @@
     "pathval": {
       "version": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "preserve": {
@@ -3861,6 +2726,22 @@
       "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
       "dev": true
     },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
     "rollup": {
       "version": "https://registry.npmjs.org/rollup/-/rollup-0.49.2.tgz",
       "integrity": "sha1-oY8HWVzeOxGHXJ/s5FslrTsiDRo=",
@@ -3986,6 +2867,12 @@
         "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "string_decoder": {
       "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
@@ -4024,10 +2911,38 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
     "type-detect": {
       "version": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
       "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
     },
     "user-home": {
       "version": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
@@ -4048,10 +2963,45 @@
         "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
       }
     },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
     "wrappy": {
       "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "rollup -c",
     "prepublish": "npm run build",
-    "test": "npm run build && mocha --compilers js:babel-core/register"
+    "test": "npm run build && mocha --compilers js:babel-core/register",
+    "cover": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --require babel-register"
   },
   "repository": {
     "type": "git",
@@ -26,7 +27,8 @@
   },
   "homepage": "https://github.com/slurmulon/stateful-dynamic-interval#readme",
   "dependencies": {
-    "dynamic-interval": "slurmulon/dynamic-interval"
+    "dynamic-interval": "slurmulon/dynamic-interval",
+    "performance-now": "^2.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -34,7 +36,8 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-es2015-rollup": "^3.0.0",
     "chai": "^4.1.1",
-    "mocha": "^3.5.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.5.3",
     "rollup": "^0.49.2",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-json": "^2.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -34,14 +34,14 @@ export class StatefulDynterval {
 
     // TODO: can probably eliminate the need for this by supporting III (immediately invoked interval) in `dynamic-interval`
     // TODO: experiment with only doing this if `config` is `null`
-    this.time.start = now() //new Date()
+    this.time.start = now()
     this.time.clock.context = context || config
 
     return context
   }
 
   run () {
-    this.time.start = now() //new Date()
+    this.time.start = now()
     this.time.clock = setDynterval(this.next.bind(this), this.context, this.api)
     this.state = STATES.running
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ export class StatefulDynterval {
 
   run () {
     this.time.start = now() //new Date()
-    this.time.clock = setDynterval(this.next.bind(this), this.context, this.api) // TODO: play with just `this.context`
+    this.time.clock = setDynterval(this.next.bind(this), this.context, this.api)
     this.state = STATES.running
 
     return this
@@ -64,7 +64,7 @@ export class StatefulDynterval {
 
     const { wait }  = this.context
     const { start } = this.time
-    const elapsed = now() - start //new Date() - this.time.start
+    const elapsed = now() - start
 
     this.time.remaining = wait - elapsed
     this.time.clock.clear()

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import setDynterval from 'dynamic-interval'
+import now from 'performance-now'
 
 // TODO: consider integrating https://github.com/medikoo/event-emitter#unifyemitter1-emitter2-event-emitterunify
 export class StatefulDynterval {
@@ -33,16 +34,18 @@ export class StatefulDynterval {
 
     // TODO: can probably eliminate the need for this by supporting III (immediately invoked interval) in `dynamic-interval`
     // TODO: experiment with only doing this if `config` is `null`
-    this.time.start = new Date()
+    this.time.start = now() //new Date()
     this.time.clock.context = context || config
 
     return context
   }
 
   run () {
-    this.time.start = new Date()
+    this.time.start = now() //new Date()
     this.time.clock = setDynterval(this.next.bind(this), this.context, this.api) // TODO: play with just `this.context`
     this.state = STATES.running
+
+    return this
   }
 
   pickup () {
@@ -59,8 +62,9 @@ export class StatefulDynterval {
   pause () {
     if (this.state !== STATES.running) return
 
-    const wait    = this.context.wait
-    const elapsed = new Date() - this.time.start
+    const { wait }  = this.context
+    const { start } = this.time
+    const elapsed = now() - start //new Date() - this.time.start
 
     this.time.remaining = wait - elapsed
     this.time.clock.clear()

--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,12 @@ export class StatefulDynterval {
     return this
   }
 
+  detach () {
+    this.children = []
+
+    return this
+  }
+
   emit (key) {
     this.children.forEach(child => {
       const action = child[key]

--- a/test/stateful-dynterval-spec.js
+++ b/test/stateful-dynterval-spec.js
@@ -160,7 +160,6 @@ describe('StatefulDynterval', () => {
       interval.resume()
 
       setTimeout(() => {
-        console.log('NEXT CALL COUNT', interval.next.callCount)
         interval.next.should.have.been.called
 
         done()

--- a/test/stateful-dynterval-spec.js
+++ b/test/stateful-dynterval-spec.js
@@ -151,7 +151,7 @@ describe('StatefulDynterval', () => {
       should.not.exist(interval.pickup())
     })
 
-    it('should call the step (next) function', done => {
+    it.only('should call the step (next) function', done => {
       interval = new StatefulDynterval(() => {}, 10)
 
       interval.next = sinon.spy()
@@ -160,6 +160,7 @@ describe('StatefulDynterval', () => {
       interval.resume()
 
       setTimeout(() => {
+        console.log('NEXT CALL COUNT', interval.next.callCount)
         interval.next.should.have.been.called
 
         done()

--- a/test/stateful-dynterval-spec.js
+++ b/test/stateful-dynterval-spec.js
@@ -151,7 +151,7 @@ describe('StatefulDynterval', () => {
       should.not.exist(interval.pickup())
     })
 
-    it.only('should call the step (next) function', done => {
+    it('should call the step (next) function', done => {
       interval = new StatefulDynterval(() => {}, 10)
 
       interval.next = sinon.spy()
@@ -164,7 +164,7 @@ describe('StatefulDynterval', () => {
         interval.next.should.have.been.called
 
         done()
-      }, 10)
+      }, 19)
     }).timeout(25)
 
     it('should call the run function', done => {


### PR DESCRIPTION
Ditches `Date` for the (much) higher precision `performance.now`

Holding off on merge until [Spectre](https://spectreattack.com/) issues are globally resolved since it inhibits any precision improvements:

https://developer.mozilla.org/en-US/docs/Web/API/Performance/now